### PR TITLE
find pubspec in subfolder first

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-type DartFlutterCommand = "flutter" | "dart";
+export type DartFlutterCommand = "flutter" | "dart";
 
 export function pubCommand(shellCommand: DartFlutterCommand): string[] {
   switch (shellCommand) {

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,9 +1,9 @@
 import * as vscode from 'vscode';
-import { getDartProjectPath } from './extension';
+import { getCommandFromPubspec, getDartProjectPath } from './extension';
 import { SigintSender } from './sigint';
 import { command, COMMANDS, deleteConflictingOutputsSuffix, isWin32, log, output, pubCommand, settings } from "./utils";
 import cp = require('child_process');
-
+import fs = require('fs');
 enum State { initializing, watching, idle, }
 
 const timeout = <T>(prom: Promise<T>, time: number) =>
@@ -155,15 +155,16 @@ export class BuildRunnerWatch {
     }
 
     let cwd = getDartProjectPath();
-
+    let cmdToUse = getCommandFromPubspec(cwd) || settings.commandToUse;
+    
     if (cwd === undefined) {
       const uri = await this.queryProject();
       if (uri === undefined) { return; } else { cwd = uri.fsPath; }
     }
+    
 
-    console.log(`cwd=${cwd}`);
+    console.log(`cwd=${cwd}`);    
 
-    const cmdToUse = settings.commandToUse;
     const cmd = command(cmdToUse);
     const args: string[] = [...pubCommand(cmdToUse), "build_runner", "watch"];
     const opts: cp.SpawnOptionsWithoutStdio = { cwd: cwd };


### PR DESCRIPTION
I was having a similar problem as #4, not sure if it was the same one:

Here is my directory structure:
```
my_project/pubspec.yaml
my_project/** // project dart scripts
my_project/packages/app/pubspec.yaml
my_project/packages/app/** // flutter package
my_project/packages/core/pubspec.yaml
my_project/packages/core/** // core dart-only package
```

Anyways, since all of my code generation happens in core, I try to `watch` from a file opened there. However, since there is a pubspec in the root of the workspace, build-runner extension tries to run there, but the pubspec there does not depend on build_runner and is not where I want to run the watch command. 

This PR searches for the pubspec starting from the file to the root of the workspace as expected.

I've also added in automatic detection to use flutter vs dart commands with a fallback on settings. The setting seems unintuitive to me, because I have a large mix of dart vs flutter projects.

Happy to address any feedback you have.