### PR TITLE
fix: windows relative path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -180,7 +180,7 @@ export function getFilters(projectPath: string | undefined): Array<string> | nul
 	const workspacePath = workspaceFolder?.uri.path;
 	if (workspacePath === undefined) { return []; }
 
-	const relativePath = path!.replace(workspacePath!, "");
+	const relativePath = path!.replace(RegExp(workspacePath, "i")!, "");
 	const segments = relativePath!.split("/").filter((e) => e !== "");
 
 	/// Guard against no top level folder

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -221,7 +221,7 @@ export function getFilters(projectPath: string | undefined): Array<string> | nul
 	const buildFilters = parts!.map((e) => `${bottomLevelFolder}/${e}`).map((e) => {
 		const p = vscode.Uri.file(e).path;
 		if (projPath === undefined) { return p; } else {
-			const rel = p.replace(projPath, "");
+			const rel = p.replace(new RegExp(projPath, "i"), "");
 			const rel2 = rel.startsWith("/") ? rel.slice(1) : rel;
 			return rel2;
 		}


### PR DESCRIPTION
## Problem
Running the extension on Windows causes an error due to the path being absolute instead of relative #16.
The problem appears to be that the project path and "path to part" are not exact. In the case of "path to part" the drive letter is upper case, while in the project path it is lower case.

## Solution
Replace the path with case insensitive. It is not the cleanest solution, but unsure how to get a matching path for the project.